### PR TITLE
feat: override include_watched w/ collection label

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Settings are set via [environment variables](https://kinsta.com/knowledgebase/wh
 |---------------------------|----------|---------------------------------------------------------------------------|
 | REPLEX_HOST               |        	 | Url of your plex instance. ex: http://0.0.0.0:32400                                             	  |
 | REPLEX_HERO_ROWS          |        	 | Comma seperated list of hubidentifiers to make hero style, options are: <br />home.movies.recent<br />movies.recent <br />movie.recentlyadded<br />movie.topunwatched<br />movie.recentlyviewed<br />hub.movie.recentlyreleased<br />movie.recentlyreleased<br />home.television.recent<br />tv.recentlyadded<br />tv.toprated<br />tv.inprogress<br />tv.recentlyaired    |
-| REPLEX_INCLUDE_WATCHED    | false    | If set to false, hide watched items for recommended rows                                     |
+| REPLEX_EXCLUDE_WATCHED    | false    | If set to true, hide watched items for recommended rows                                     |
 | REPLEX_DISABLE_CONTINUE_WATCHING | false    | Disable/remove the continue watching row |
 | REPLEX_DISABLE_USER_STATE | false    | Remove unplayed badges from row items |
 | REPLEX_DISABLE_LEAF_COUNT| false    | Remove episode count label from show artwork.                              |
@@ -121,6 +121,10 @@ For built in rows you can use the hubidentifier in the `REPLEX_HERO_ROWS`. See t
 
 Note: hero style elements uses coverart from plex. Banner or background is not used.
 Note: Hero elements are not supported for continue watching by plex. You can replicate this functionality by creating a smart collection which filters on in progress and settinf REPLEX_DISABLE_CONTINUE_WATCHING
+
+## Exclude watched items
+
+If you want to hide watched items from your rows, you can set `REPLEX_EXCLUDE_WATCHED` to true. Alternatively, you can add the label "REPLEX_EXCLUDE_WATCHED" to a collection to exclude watched items from that collection only.
 
 
 ## Remote access (force clients to use the proxy)
@@ -156,7 +160,7 @@ You can redirect streams by enabling `REPLEX_REDIRECT_STREAMS` and optionally se
 
 - hero rows on Android devices dont load more content. so hero rows have a maximum of 100 items on Android.
 - On android mobile hero elements in libraries are slightly cutoff. This is plex limitation.
-- when include_watched is false a maximum item limit per library is opposed of 250 items. So if you have a mixed row of 2 libraries the max results of that row will be 500 items.
+- when exclude_watched is true a maximum item limit per library is opposed of 250 items. So if you have a mixed row of 2 libraries the max results of that row will be 500 items.
 - disable_user_state: For movies this works in the webapp. Shows work accross clients
 
 ## Help it doesnt work!

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,7 @@ pub struct Config {
         default = "default_as_false",
         deserialize_with = "figment::util::bool_from_str_or_int"
     )]
-    pub include_watched: bool,
+    pub exclude_watched: bool,
     #[serde(default = "default_cache_ttl")]
     pub cache_ttl: u64,
     #[serde(

--- a/src/models.rs
+++ b/src/models.rs
@@ -1398,7 +1398,7 @@ impl MetaData {
         false
     }
 
-    pub async fn include_watched(
+    pub async fn exclude_watched(
         &self,
         plex_client: PlexClient,
     ) -> Result<bool> {
@@ -1417,13 +1417,13 @@ impl MetaData {
             )
             .await?;
 
-        Ok(config.include_watched
+        Ok(config.exclude_watched
             || collection
                 .media_container
                 .metadata
                 .get(0)
                 .unwrap()
-                .has_label("REPLEX_INCLUDE_WATCHED".to_string()))
+                .has_label("REPLEX_EXCLUDE_WATCHED".to_string()))
     }
 
     // TODO: Does not work when using a new instance
@@ -1712,15 +1712,15 @@ impl MediaContainer {
         !self.hub.is_empty()
     }
 
-    pub fn include_watched(&self) -> bool {
+    pub fn exclude_watched(&self) -> bool {
         let config: Config = Config::figment().extract().unwrap();
 
-        return config.include_watched
+        return config.exclude_watched
             || self
                 .metadata
                 .get(0)
                 .unwrap()
-                .has_label("REPLEX_INCLUDE_WATCHED".to_string());
+                .has_label("REPLEX_EXCLUDE_WATCHED".to_string());
     }
 
     pub fn set_type(&mut self, value: String) {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -616,8 +616,14 @@ pub async fn default_transform(
     let rest_path = req.param::<String>("**rest").unwrap();
 
     // We dont listen to pagination. We have a hard max of 250 per collection
-    let limit: i32 = 250;
-    let offset: i32 = 0;
+    let mut limit: i32 = 250;
+    let mut offset: i32 = 0;
+
+    // in we dont remove watched then we dont need to limit
+    if !config.exclude_watched {
+        limit = params.container_size.unwrap_or(50);
+        offset = params.container_start.unwrap_or(0);
+    }
 
     let mut url = Url::parse(req.uri_mut().to_string().as_str()).unwrap();
     url.set_path(&rest_path);

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -562,8 +562,14 @@ pub async fn get_collections_children(
     let content_type = get_content_type_from_headers(req.headers_mut());
 
     // We dont listen to pagination. We have a hard max of 250 per collection
-    let limit: i32 = 250;
-    let offset: i32 = 0;
+    let mut limit: i32 = 250;
+    let mut offset: i32 = 0;
+
+    // in we dont remove watched then we dont need to limit
+    if !config.exclude_watched {
+        limit = params.container_size.unwrap_or(50);
+        offset = params.container_start.unwrap_or(0);
+    }
 
     // create a stub
     let mut container: MediaContainerWrapper<MediaContainer> =

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -464,6 +464,7 @@ pub async fn transform_hubs_home(
     TransformBuilder::new(plex_client, params.clone())
         .with_transform(HubStyleTransform { is_home: true })
         // .with_transform(HubSectionDirectoryTransform)
+        .with_transform(HubWatchedTransform)
         .with_transform(HubMixTransform)
         // .with_transform(HubChildrenLimitTransform {
         //     limit: params.clone().count.unwrap(),
@@ -522,11 +523,12 @@ pub async fn get_hubs_sections(
     TransformBuilder::new(plex_client, params.clone())
         .with_transform(HubSectionDirectoryTransform)
         .with_transform(HubStyleTransform { is_home: false })
+        .with_transform(HubWatchedTransform)
         .with_transform(UserStateTransform)
         .with_transform(HubKeyTransform)
         //.with_transform(MediaContainerScriptingTransform)
         // .with_filter(CollectionHubPermissionFilter)
-        .with_filter(WatchedFilter)
+        // .with_filter(WatchedFilter)
         .apply_to(&mut container)
         .await;
     // dbg!(container.media_container.count);

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -440,7 +440,7 @@ pub async fn transform_hubs_home(
         _ => (),
     }
     // Hack, as the list could be smaller when removing watched items. So we request more.
-    if !config.include_watched && count < 50 {
+    if config.exclude_watched && count < 50 {
         count = 50;
     }
 
@@ -496,7 +496,7 @@ pub async fn get_hubs_sections(
     }
 
     // Hack, as the list could be smaller when removing watched items. So we request more.
-    if !config.include_watched && count < 50 {
+    if config.exclude_watched && count < 50 {
         count = 50;
     }
 
@@ -562,14 +562,8 @@ pub async fn get_collections_children(
     let content_type = get_content_type_from_headers(req.headers_mut());
 
     // We dont listen to pagination. We have a hard max of 250 per collection
-    let mut limit: i32 = 250;
-    let mut offset: i32 = 0;
-
-    // in we dont remove watched then we dont need to limit
-    if config.include_watched {
-        limit = params.container_size.unwrap_or(50);
-        offset = params.container_start.unwrap_or(0);
-    }
+    let limit: i32 = 250;
+    let offset: i32 = 0;
 
     // create a stub
     let mut container: MediaContainerWrapper<MediaContainer> =
@@ -616,14 +610,8 @@ pub async fn default_transform(
     let rest_path = req.param::<String>("**rest").unwrap();
 
     // We dont listen to pagination. We have a hard max of 250 per collection
-    let mut limit: i32 = 250;
-    let mut offset: i32 = 0;
-
-    // in we dont remove watched then we dont need to limit
-    if config.include_watched {
-        limit = params.container_size.unwrap_or(50);
-        offset = params.container_start.unwrap_or(0);
-    }
+    let limit: i32 = 250;
+    let offset: i32 = 0;
 
     let mut url = Url::parse(req.uri_mut().to_string().as_str()).unwrap();
     url.set_path(&rest_path);

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -327,9 +327,6 @@ impl Transform for HubMixTransform {
                 continue;
             }
 
-            if !config.include_watched {
-                hub.children_mut().retain(|x| !x.is_watched());
-            }
             //hub.context = Some("hub.home.watchlist_available".to_string());
             //hub.r#type = "clip".to_string();
             // hub.placeholder = Some(SpecialBool::new(true));
@@ -422,7 +419,7 @@ impl Transform for LibraryMixTransform {
     ) -> MediaContainer {
         let config: Config = Config::figment().extract().unwrap();
         let mut children: Vec<MetaData> = vec![];
-        let mut total_size_including_watched = 0;
+        let mut total_size = 0;
 
         for id in self.collection_ids.clone() {
             let mut c = plex_client
@@ -441,11 +438,20 @@ impl Transform for LibraryMixTransform {
                 .await
                 .unwrap();
 
-            total_size_including_watched +=
-                c.media_container.total_size.unwrap();
-            if !config.include_watched {
+            let collection = plex_client
+                .clone()
+                .get_cached(
+                    plex_client.get_collection(id as i32),
+                    format!("collection:{}", id.to_string()),
+                )
+                .await
+                .unwrap();
+
+            if !collection.media_container.include_watched() {
                 c.media_container.children_mut().retain(|x| !x.is_watched());
             }
+
+            total_size += c.media_container.children().len() as i32;
 
             match children.is_empty() {
                 false => {
@@ -457,11 +463,7 @@ impl Transform for LibraryMixTransform {
                 true => children.append(&mut c.media_container.children()),
             }
         }
-        if !config.include_watched {
-            item.total_size = Some(children.len() as i32);
-        } else {
-            item.total_size = Some(total_size_including_watched);
-        };
+        item.total_size = Some(total_size);
         // always metadata
         item.metadata = children;
         item
@@ -684,6 +686,32 @@ impl Transform for HubStyleTransform {
                 }
                 let children: Vec<MetaData> = futures.collect().await;
                 item.set_children(children);
+            }
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct HubWatchedTransform;
+
+#[async_trait]
+impl Transform for HubWatchedTransform {
+    async fn transform_metadata(
+        &self,
+        item: &mut MetaData,
+        plex_client: PlexClient,
+        options: PlexContext,
+    ) {
+        let config: Config = Config::figment().extract().unwrap();
+
+        if item.is_hub() {
+            let include_watched = item
+                .include_watched(plex_client.clone())
+                .await
+                .unwrap_or(false);
+
+            if !include_watched {
+                item.children_mut().retain(|x| !x.is_watched());
             }
         }
     }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -447,7 +447,7 @@ impl Transform for LibraryMixTransform {
                 .await
                 .unwrap();
 
-            if !collection.media_container.include_watched() {
+            if collection.media_container.exclude_watched() {
                 c.media_container.children_mut().retain(|x| !x.is_watched());
             }
 
@@ -705,12 +705,12 @@ impl Transform for HubWatchedTransform {
         let config: Config = Config::figment().extract().unwrap();
 
         if item.is_hub() {
-            let include_watched = item
-                .include_watched(plex_client.clone())
+            let exclude_watched = item
+                .exclude_watched(plex_client.clone())
                 .await
                 .unwrap_or(false);
 
-            if !include_watched {
+            if exclude_watched {
                 item.children_mut().retain(|x| !x.is_watched());
             }
         }
@@ -844,8 +844,8 @@ impl Filter for WatchedFilter {
         options: PlexContext,
     ) -> bool {
         let config: Config = Config::figment().extract().unwrap();
-        if config.include_watched {
-            return true;
+        if config.exclude_watched {
+            return false;
         }
 
         if !item.is_hub() {


### PR DESCRIPTION
### feat: override include_watched w/ collection label
- Added `include_watched` method to `MetaData` and `MediaContainer` models, looks at both env var and collection label.
- Added `HubWatchedTransform` and use it for `get_hubs_sections` and `transform_hubs_home` route handlers.
- Removed `WatchedFilter` from `transform_hubs_home` route handler, filtering is now handled by transform.
- Removed include_watched logic from `HubMixTransform` (this is now done in `HubWatchedTransform`).
- Improve include_watched logic in `LibraryMixTransform`, account for collection label and get correct size.


### feat: change include_watched to exclude_watched
- Changed include_watched to exclude_watched in config and models.
- Inverted logic in trasforms.
- Removed logic from limit in route handler, not sure if this is correct.
- Updated readme.